### PR TITLE
adding an option to specify a KMS key for snapshot encryption

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,7 @@ Options:
 -i,--instance-type Set EC2 instance type to build this snapshot, (default: m5.large)
 -R,--instance-role Name of existing IAM role for created EC2 instance, (default: Create on launching)
 -q,--quiet Suppress all outputs and output generated snapshot ID only (default: false)
+-k,--kms-id Use a specific KMS Key Id to encrypt this snapshot
 ```
 
 ## Required IAM Policy
@@ -78,8 +79,13 @@ This script requires the following IAM policies:
 "ssm:ListCommandInvocations",
 "ssm:GetCommandInvocation",
 "ssm:DescribeInstanceProperties",
-"ssm:GetParameters"
+"ssm:GetParameters",
+"kms:DescribeKey",
+"kms:GenerateDataKey",
+"kms:Decrypt"
 ```
+
+The KMS actions are only required when using the `--kms-id` option.
 
 ## Using snapshot with Amazon EKS
 

--- a/README.md
+++ b/README.md
@@ -80,8 +80,12 @@ This script requires the following IAM policies:
 "ssm:GetCommandInvocation",
 "ssm:DescribeInstanceProperties",
 "ssm:GetParameters",
+"kms:RetireGrant",
+"kms:CreateGrant",
+"kms:ReEncrypt*",
+"kms:GenerateDataKey*",
+"kms:Encrypt",
 "kms:DescribeKey",
-"kms:GenerateDataKey",
 "kms:Decrypt"
 ```
 

--- a/ebs-snapshot-instance.yaml
+++ b/ebs-snapshot-instance.yaml
@@ -17,9 +17,14 @@ Parameters:
     Type: String
     Description: "Name of IAM Role used in instance"
     Default: NONE
+  KMSId:
+    Type: String
+    Description: "Id of the KMS Key used for the snapshot"
+    Default: NONE
 
 Conditions:
   CreateNewIAMRole: !Equals [!Ref InstanceRole, NONE]
+  UseCustomKMSId: !Not [!Equals [!Ref KMSId, NONE]]
 
 Resources:
   BottlerocketNodeRole:
@@ -70,6 +75,12 @@ Resources:
           Ebs:
             VolumeSize: 50
             VolumeType: gp3
+            Encrypted: true
+            KmsKeyId: 
+              Fn::If:
+                - UseCustomKMSId
+                - !Ref KMSId
+                - !Ref AWS::NoValue
             Throughput: 1000
             Iops: 4000
             DeleteOnTermination: true


### PR DESCRIPTION
The script was always taking the default AWS KMS EBS key to encrypt the instance and the resulting snapshot.
That's an issue when you want to share that snapshot with another account, as [this is only possible by using a custom KMS key](https://repost.aws/knowledge-center/share-encrypted-rds-snapshot-kms-key)

*Description of changes:*
This PR adds a `-k` option to specify a KMS key to use for the temporary instance's volume encryption, and thus for the snapshot.