### PR TITLE
feat: Add network configuration options to snapshot creation script

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,15 +37,18 @@ $ ./snapshot.sh -h
 usage: ./snapshot.sh [options] <comma seperated container images>
 Build EBS snapshot for Bottlerocket data volume with cached container images
 Options:
--h,--help print this help
--r,--region Set AWS region to build the EBS snapshot, (default: use environment variable of AWS_DEFAULT_REGION, or IMDS if running on EC2)
--a,--ami Set SSM Parameter path for Bottlerocket ID, (default: /aws/service/bottlerocket/aws-k8s-1.27/x86_64/latest/image_id)
--i,--instance-type Set EC2 instance type to build this snapshot, (default: m5.large)
--R,--instance-role Name of existing IAM role for created EC2 instance, (default: Create on launching)
--q,--quiet Suppress all outputs and output generated snapshot ID only (default: false)
+-h,--help Print this help.
+-r,--region Set AWS region to build the EBS snapshot. (default: use environment variable of AWS_DEFAULT_REGION or IMDS)
+-a,--ami Set SSM Parameter path for Bottlerocket ID. (default: /aws/service/bottlerocket/aws-k8s-1.27/x86_64/latest/image_id)
+-i,--instance-type Set EC2 instance type to build this snapshot. (default: m5.large)
 -e,--encrypt Encrypt the generated snapshot. (default: false)
 -k,--kms-id Use a specific KMS Key Id to encrypt this snapshot, should use together with -e
 -s,--snapshot-size Use a specific volume size (in GiB) for this snapshot. (default: 50)
+-R,--instance-role Name of existing IAM role for created EC2 instance. (default: Create on launching)
+-q,--quiet Redirect output to stderr and output generated snapshot ID to stdout only. (default: false)
+-sg,--security-group-id Set a specific Security Group ID for the instance. (default: use default VPC security group)
+-sn,--subnet-id Set a specific Subnet ID for the instance. (default: use default VPC subnet)
+-p,--public-ip Associate a public IP address with the instance. (default: true)
 ```
 
 ## Required IAM Policy

--- a/ebs-snapshot-instance.yaml
+++ b/ebs-snapshot-instance.yaml
@@ -1,8 +1,7 @@
 # Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 # SPDX-License-Identifier: MIT-0
-
 AWSTemplateFormatVersion: 2010-09-09
-Description: Bottlerocket instance to snapshot data volume.
+Description: Bottlerocket instance to snapshot data volume with configurable network settings.
 
 Parameters:
   AmiID:
@@ -29,11 +28,28 @@ Parameters:
     Type: Number
     Description: "Size of the target snapshot"
     Default: 50
+  SecurityGroupId:
+    Type: String
+    Description: "Optional Security Group ID. If not provided, the default VPC security group will be used."
+    Default: ""
+  SubnetId:
+    Type: String
+    Description: "Optional Subnet ID. If not provided, a subnet from the default VPC will be used."
+    Default: ""
+  AssociatePublicIpAddress:
+    Type: String
+    Description: "Whether to associate a public IP address to the instance"
+    Default: "true"
+    AllowedValues:
+      - "true"
+      - "false"
 
 Conditions:
   CreateNewIAMRole: !Equals [!Ref InstanceRole, NONE]
   UseCustomKMSId: !Not [!Equals [!Ref KMSId, NONE]]
   Encrypt: !Not [!Equals [!Ref Encrypt, NONE]]
+  UseCustomSecurityGroup: !Not [!Equals [!Ref SecurityGroupId, NONE]]
+  UseCustomSubnet: !Not [!Equals [!Ref SubnetId, NONE]]
 
 Resources:
   BottlerocketNodeRole:
@@ -97,6 +113,12 @@ Resources:
             Throughput: 1000
             Iops: 4000
             DeleteOnTermination: true
+        NetworkInterfaces:
+          - AssociatePublicIpAddress: !Ref AssociatePublicIpAddress
+            DeviceIndex: "0"
+            Groups:
+              - !If [UseCustomSecurityGroup, !Ref SecurityGroupId, !Ref 'AWS::NoValue']
+            SubnetId: !If [UseCustomSubnet, !Ref SubnetId, !Ref 'AWS::NoValue']
 
   BottlerocketInstance:
     Type: AWS::EC2::Instance
@@ -104,7 +126,6 @@ Resources:
       LaunchTemplate:
         LaunchTemplateId: !Ref BottlerocketLaunchTemplate
         Version: !GetAtt BottlerocketLaunchTemplate.LatestVersionNumber
-
 
 Outputs:
   InstanceId:

--- a/ebs-snapshot-instance.yaml
+++ b/ebs-snapshot-instance.yaml
@@ -31,11 +31,11 @@ Parameters:
   SecurityGroupId:
     Type: String
     Description: "Optional Security Group ID. If not provided, the default VPC security group will be used."
-    Default: ""
+    Default: NONE
   SubnetId:
     Type: String
     Description: "Optional Subnet ID. If not provided, a subnet from the default VPC will be used."
-    Default: ""
+    Default: NONE
   AssociatePublicIpAddress:
     Type: String
     Description: "Whether to associate a public IP address to the instance"

--- a/snapshot.sh
+++ b/snapshot.sh
@@ -151,7 +151,7 @@ export AWS_PAGER=""
 
 # launch EC2
 log "[1/8] Deploying EC2 CFN stack ..."
-RAND=$(echo $RANDOM | md5sum | head -c 4)
+RAND=$(od -An -N2 -i /dev/urandom | tr -d ' ' | cut -c1-4)
 CFN_STACK_NAME="Bottlerocket-ebs-snapshot-$RAND"
 CFN_PARAMS="AmiID=$AMI_ID InstanceType=$INSTANCE_TYPE InstanceRole=$INSTANCE_ROLE Encrypt=$ENCRYPT KMSId=$KMS_ID SnapshotSize=$SNAPSHOT_SIZE SecurityGroupId=$SECURITY_GROUP_ID SubnetId=$SUBNET_ID AssociatePublicIpAddress=$ASSOCIATE_PUBLIC_IP"
 

--- a/snapshot.sh
+++ b/snapshot.sh
@@ -108,6 +108,7 @@ while [[ $# -gt 0 ]]; do
         -p|--public-ip)
             ASSOCIATE_PUBLIC_IP=true
             shift
+            shift
             ;;
         *)
             POSITIONAL+=("$1") # save it in an array for later

--- a/snapshot.sh
+++ b/snapshot.sh
@@ -106,7 +106,7 @@ while [[ $# -gt 0 ]]; do
             shift
             ;;
         -p|--public-ip)
-            ASSOCIATE_PUBLIC_IP=true
+            ASSOCIATE_PUBLIC_IP=$2
             shift
             shift
             ;;
@@ -131,6 +131,7 @@ KMS_ID=${KMS_ID:-NONE}
 SNAPSHOT_SIZE=${SNAPSHOT_SIZE:-50}
 SECURITY_GROUP_ID=${SECURITY_GROUP_ID:-NONE}
 SUBNET_ID=${SUBNET_ID:-NONE}
+ASSOCIATE_PUBLIC_IP=${ASSOCIATE_PUBLIC_IP:-true}
 SCRIPTPATH=$(dirname "$0")
 CTR_CMD="apiclient exec admin sheltie ctr -a /run/containerd/containerd.sock -n k8s.io"
 


### PR DESCRIPTION
## Description
This PR addresses the need for more flexible network configuration when creating Bottlerocket EBS snapshots. It adds options to specify a security group, subnet, and whether to associate a public IP address. These changes allow users to better control the network environment of the temporary EC2 instance used in the snapshot creation process.

## Changes
- Added new command-line options to `snapshot.sh`:
  - `-sg` or `--security-group-id`: Set a specific Security Group ID
  - `-sn` or `--subnet-id`: Set a specific Subnet ID
  - `-p` or `--public-ip`: Associate a public IP address with the instance
- Updated the CloudFormation parameter passing in `snapshot.sh` to include these new options
- Enhanced the script's help text to describe the new options
- Modified the CloudFormation template to accept and use these new parameters

## Motivation
This change was motivated by the following issue: #6 
