### PR TITLE
Update the ctr images pull parameter order

### DIFF
--- a/snapshot.sh
+++ b/snapshot.sh
@@ -218,7 +218,7 @@ do
     for PLATFORM in "${ARCH_LIST[@]}"
     do
         log "Pulling $IMG - $PLATFORM ... "
-        COMMAND="$CTR_CMD images pull --label io.cri-containerd.image=managed --platform $PLATFORM $IMG $ECRPWD"
+        COMMAND="$CTR_CMD images pull --label io.cri-containerd.image=managed --platform $PLATFORM $ECRPWD $IMG"
         CMDID=$(aws ssm send-command --instance-ids "$INSTANCE_ID" \
             --document-name "AWS-RunShellScript" --comment "Pull Image ${IMG:0:75} - $PLATFORM" \
             --parameters commands="$COMMAND" \


### PR DESCRIPTION
When attempting to use this script with Kubernetes 1.33, it failed to authenticate against ECR when pulling the images. After some investigation, it appears that `ctr` in containerd 2.0 is more strict about its parameter ordering and wants all flags to come before the image reference. This change simply moves the `$ECRPWD` variable containing the `--u` and `--region` flags before the image reference.